### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/lock-set.js
+++ b/lib/lock-set.js
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const pasync = require('pasync');
 const Profiler = require('simprof');
 const ResourceLockedError = require('./resource-locked-error');

--- a/lib/locker.js
+++ b/lib/locker.js
@@ -4,7 +4,7 @@
 
 const path = require('path');
 const pasync = require('pasync');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const Profiler = require('simprof');
 const ResourceLockedError = require('./resource-locked-error');
 const RWLock = require('./rwlock');

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "dependencies": {
     "babel-runtime": "5.8.24",
     "lodash": "^3.10.1",
-    "node-uuid": "^1.4.3",
     "pasync": "^1.4.0",
-    "xerror": "^1.0.0",
-    "simprof": "^1.2.5"
+    "simprof": "^1.2.5",
+    "uuid": "^3.0.0",
+    "xerror": "^1.0.0"
   },
   "devDependencies": {
     "broccoli": "^0.16.8",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.