### PR TITLE
Feature/more debug info

### DIFF
--- a/lib/lock-set.js
+++ b/lib/lock-set.js
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0
 // http://www.apache.org/licenses/LICENSE-2.0
 
-const uuid = require('node-uuid');
 const pasync = require('pasync');
 const Profiler = require('simprof');
 const ResourceLockedError = require('./resource-locked-error');
@@ -25,7 +24,7 @@ class LockSet extends LockerBase {
 		this.locks = {};
 		this.dependentLockSets = [];
 		this.locker = locker;
-		this.tokenBase = uuid.v4().substr(0, 17);
+		this.tokenBase = this._generateTokenBase();
 	}
 
 	/**

--- a/lib/locker-base.js
+++ b/lib/locker-base.js
@@ -5,6 +5,12 @@
 const pasync = require('pasync');
 const _ = require('lodash');
 const XError = require('xerror');
+const uuid = require('node-uuid');
+const os = require('os');
+const process = require('process');
+
+const hostname = os.hostname();
+const pid = process.pid;
 
 /**
  * Base class for Locker and LockSet.  Contains common code shared between the two of them.
@@ -12,6 +18,10 @@ const XError = require('xerror');
  * @class LockerBase
  */
 class LockerBase {
+
+	_generateTokenBase() {
+		return `TOK-${hostname}-${pid}-${uuid.v4().substr(0, 8)}`;
+	}
 
 	/**
 	 * Creates a new lock set.

--- a/lib/locker.js
+++ b/lib/locker.js
@@ -4,12 +4,12 @@
 
 const path = require('path');
 const pasync = require('pasync');
-const uuid = require('node-uuid');
 const Profiler = require('simprof');
 const ResourceLockedError = require('./resource-locked-error');
 const RWLock = require('./rwlock');
 const LockSet = require('./lock-set');
 const LockerBase = require('./locker-base');
+const XError = require('xerror');
 const _ = require('lodash');
 
 const profiler = new Profiler('Locker');
@@ -34,7 +34,7 @@ class Locker extends LockerBase {
 		super();
 		this.redizClient = redizClient;
 		this.prefix = options.prefix || 'rzlock:';
-		this.tokenBase = uuid.v4().substr(0, 17);
+		this.tokenBase = this._generateTokenBase();
 		this.tokenCtr = 1;
 		this.scriptWaiter = pasync.waiter();
 		// In the constructor, read in the lua script files and register them with redizClient
@@ -108,6 +108,7 @@ class Locker extends LockerBase {
 	readLock(key, options = {}) {
 		let prof = profiler.begin('#readLock');
 		let lastLockHolder = null;
+		let numLockHolders = 0;
 
 		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout } =
 			_.defaults(options, this.defaults);
@@ -130,9 +131,14 @@ class Locker extends LockerBase {
 							lockTimeout
 						)
 							.then((result) => {
-								if (result[0] === 1) return true;
+								if (result[0] === 1) {
+									// Acquired a shared read lock
+									return true;
+								}
+								// A write lock already exists on this key
 								if (lastLockHolder !== null && result[1] !== lastLockHolder) {
 									lastLockHolder = result[1];
+									numLockHolders++;
 									return 'reset';
 								}
 								lastLockHolder = result[1];
@@ -144,6 +150,18 @@ class Locker extends LockerBase {
 			})
 			.then( () => {
 				return new RWLock(this, key, undefined, false, heartbeatInterval, heartbeatTimeout);
+			})
+			.catch((err) => {
+				if (err.code === XError.RESOURCE_LOCKED) {
+					if (!err.data) err.data = {};
+					err.data.key = key;
+					err.data.lockType = 'read';
+					err.data.maxWaitTime = maxWaitTime;
+					err.data.ownTokenBase = this.tokenBase;
+					err.data.holder = lastLockHolder;
+					err.data.numHolders = numLockHolders;
+				}
+				throw err;
 			})
 			.then(prof.wrappedEnd());
 	}
@@ -179,6 +197,7 @@ class Locker extends LockerBase {
 	writeLock(key, options = {}) {
 		let prof = profiler.begin('#writeLock');
 		let lastLockHolder = null;
+		let numLockHolders = 0;
 
 		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout } =
 			_.defaults(options, this.defaults);
@@ -197,6 +216,7 @@ class Locker extends LockerBase {
 			.then(() => {
 				let writeLockClaimed = false;
 				let client = this.redizClient.shard(key, { downNodeExpiry });
+				// Keep trying to establish the lock until we get it or exceed the maximum wait time
 				return this._retryUntilTimeOut(
 					() => {
 						return client.runScript(
@@ -208,21 +228,32 @@ class Locker extends LockerBase {
 						)
 						.then((result) => {
 							if (result[0] === 2) {
+								// We have successfully claimed the write lock, but a read lock on the
+								// same key already exists, so we have to wait until all read locks are
+								// released to complete exclusive acquisition of the write lock.
 								let retVal = writeLockClaimed ? false : 'reset';
 								writeLockClaimed = true;
 								return retVal;
 							} else if (result[0] === 1) {
+								// Successfully acquired the write lock and there's no existing read lock.
+								// Lock acquisition is complete.
 								return true;
 							} else {
+								// There is an existing write lock held by token result[1]
 								if (resolveConflicts) {
+									// If conflict resolution mode, the lock with the lower token "wins"
 									if (result[1] < token) {
 										lostConflictResolution = true;
+										lastLockHolder = result[1];
+										numLockHolders++;
 										return true;
 									}
 								}
 								writeLockClaimed = false;
 								if (lastLockHolder !== null && lastLockHolder !== result[1]) {
+									// Every time the lock changes hands, reset the wait timer.
 									lastLockHolder = result[1];
+									numLockHolders++;
 									return 'reset';
 								} else if (lastLockHolder !== null) {
 									lastLockHolder = result[1];
@@ -239,12 +270,30 @@ class Locker extends LockerBase {
 						if (writeLockClaimed) {
 							client.runScript('writeLockRelease', this.prefix + ':write:' + key, token);
 						}
+						if (err.code === XError.RESOURCE_LOCKED) {
+							if (!err.data) err.data = {};
+							err.data.key = key;
+							err.data.lockType = 'write';
+							err.data.maxWaitTime = maxWaitTime;
+							err.data.ownToken = token;
+							err.data.ownTokenBase = this.tokenBase;
+							err.data.holder = lastLockHolder;
+							err.data.numHolders = numLockHolders;
+						}
 						throw err;
 					});
 			})
 			.then(() => {
 				if (lostConflictResolution) {
-					throw new ResourceLockedError(key, 'Lost lock conflict resolution for: ' + key);
+					throw new ResourceLockedError(key, 'Lost lock conflict resolution for: ' + key, {
+						key,
+						lockType: 'write',
+						maxWaitTime,
+						ownToken: token,
+						ownTokenBase: this.tokenBase,
+						holder: lastLockHolder,
+						numHolders: numLockHolders
+					});
 				} else {
 					return new RWLock(this, key, token, true, heartbeatInterval, heartbeatTimeout);
 				}
@@ -256,7 +305,7 @@ class Locker extends LockerBase {
 	 * Continually tries to run the given function, until it timesout or successfully returns.
 	 *
 	 * @private
-	 * @method _unlockRead
+	 * @method _retryUntilTimeOut
 	 * @params {Function} func - a function that returns a promise, normally a script to run on the client.
 	 *  The result should return true, or false.
 	 *	if true, the promise will resolve, if fails, it will retry over, and over depending upon the timeout given.

--- a/lib/locker.js
+++ b/lib/locker.js
@@ -100,6 +100,8 @@ class Locker extends LockerBase {
 	 *     false to disable heartbeats.
 	 *   @param {Number} [options.heartbeatTimeout] - What each heartbeat should update the timeout
 	 *     to.  Defaults to three times the heartbeatInterval.
+	 *   @param {Number} [options.warnTime] - If supplied, after `warnTime` number of seconds of
+	 *     waiting for the lock, a warning is printed to stderr.
 	 * @return {Promise{RWLock}} - Resolves with the RWLock instance which is used to release (or
 	 *   upgrade) the lock instance.  Rejects with an XError.  If the lock cannot be acquired
 	 *   because of a `maxWaitTime` timeout, this rejects with a `ResourceLockedError` (an XError
@@ -109,8 +111,9 @@ class Locker extends LockerBase {
 		let prof = profiler.begin('#readLock');
 		let lastLockHolder = null;
 		let numLockHolders = 0;
+		let outputWarningMessage = false;
 
-		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout } =
+		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout, warnTime } =
 			_.defaults(options, this.defaults);
 		if (heartbeatInterval === undefined) {
 			heartbeatInterval = lockTimeout ? (Math.floor(lockTimeout * 1000 / 3)) : false;
@@ -146,9 +149,26 @@ class Locker extends LockerBase {
 							});
 					},
 					maxWaitTime,
-					key);
+					key,
+					warnTime,
+					(key, time) => {
+						outputWarningMessage = true;
+						console.warn(`Taking a long time to acquire read lock ${key}`, {
+							key,
+							lockType: 'read',
+							maxWaitTime,
+							ownTokenBase: this.tokenBase,
+							holder: lastLockHolder,
+							numHolders: numLockHolders,
+							currentWaitTime: time
+						});
+					}
+				);
 			})
 			.then( () => {
+				if (outputWarningMessage) {
+					console.log(`Read lock on ${key} eventually obtained.`);
+				}
 				return new RWLock(this, key, undefined, false, heartbeatInterval, heartbeatTimeout);
 			})
 			.catch((err) => {
@@ -192,14 +212,16 @@ class Locker extends LockerBase {
 	 *     cluster node went down.
 	 *   @param {Number} [options.heartbeatInterval]
 	 *   @param {Number} [options.heartbeatTimeout]
+	 *   @param {Number} [options.warnTime]
 	 * @return {Promise{RWLock}}
 	 */
 	writeLock(key, options = {}) {
 		let prof = profiler.begin('#writeLock');
 		let lastLockHolder = null;
 		let numLockHolders = 0;
+		let outputWarningMessage = false;
 
-		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout } =
+		let { maxWaitTime, lockTimeout, downNodeExpiry, heartbeatInterval, heartbeatTimeout, warnTime } =
 			_.defaults(options, this.defaults);
 		if (heartbeatInterval === undefined) {
 			heartbeatInterval = lockTimeout ? (Math.floor(lockTimeout * 1000 / 3)) : false;
@@ -263,7 +285,21 @@ class Locker extends LockerBase {
 						});
 					},
 					maxWaitTime,
-					key
+					key,
+					warnTime,
+					(key, time) => {
+						outputWarningMessage = true;
+						console.warn(`Taking a long time to acquire write lock ${key}`, {
+							key,
+							lockType: 'write',
+							maxWaitTime,
+							ownToken: token,
+							ownTokenBase: this.tokenBase,
+							holder: lastLockHolder,
+							numHolders: numLockHolders,
+							currentWaitTime: time
+						});
+					}
 				)
 					.catch((err) => {
 						// Make sure any claimed locks are cleaned up on error
@@ -295,6 +331,9 @@ class Locker extends LockerBase {
 						numHolders: numLockHolders
 					});
 				} else {
+					if (outputWarningMessage) {
+						console.warn(`Write lock on ${key} eventually obtained.`);
+					}
 					return new RWLock(this, key, token, true, heartbeatInterval, heartbeatTimeout);
 				}
 			})
@@ -306,17 +345,22 @@ class Locker extends LockerBase {
 	 *
 	 * @private
 	 * @method _retryUntilTimeOut
-	 * @params {Function} func - a function that returns a promise, normally a script to run on the client.
+	 * @param {Function} func - a function that returns a promise, normally a script to run on the client.
 	 *  The result should return true, or false.
 	 *	if true, the promise will resolve, if fails, it will retry over, and over depending upon the timeout given.
 	 *  The special value "reset" can also be returned which resets the retry time.
-	 * @params {Number} timeout - the amount of time in seconds to retry the given function.
-	 * @params {String} key - the key that we are trying to run on the function. This is used for a reject error.
+	 * @param {Number} timeout - the amount of time in seconds to retry the given function.
+	 * @param {String} key - the key that we are trying to run on the function. This is used for a reject error.
+	 * @param {Number} warnTime - If this is given, the supplied `warn` function will be called after this
+	 *   number of seconds.  It will only be called once.
+	 * @param {Function} warn - A function to display a warning that we're waiting a long time on a lock.  This
+	 *   function has the signature function(key, totalWaitTime)
 	 * @return {Promise}
 	 */
-	_retryUntilTimeOut(func, timeout, key) {
+	_retryUntilTimeOut(func, timeout, key, warnTime, warn) {
 		let totalWaitTime = 0;
 		let initialWaitTime = 5;
+		let calledWarn = false;
 		let retry = (waitTime) => {
 			let timeoutPromise = (resetWaitTime) => {
 				if (!timeout) {
@@ -327,6 +371,12 @@ class Locker extends LockerBase {
 						new ResourceLockedError(key, 'Timed out trying to get a resource lock for: ' + key));
 				}
 				totalWaitTime += waitTime;
+				if (warnTime && totalWaitTime >= warnTime && !calledWarn) {
+					calledWarn = true;
+					if (warn) {
+						warn(key, totalWaitTime);
+					}
+				}
 				return new Promise( (resolve) => {
 					setTimeout( () => {
 						let newWaitTime = waitTime * 3 + Math.floor(Math.random() * 3);


### PR DESCRIPTION
This adds a few additional simple debugging capabilities.  The changes included are:

- Lock tokens are now based on hostname and PID instead of just a UUID to allow for easier identification of which host and process is holding a lock.
- Extra useful information is now included in the data object of lock errors.
- Add the ability to configure a warning to be output if a lock takes too long to acquire.
- Added and fixed several comments.
